### PR TITLE
Make drop size limits upgradable

### DIFF
--- a/BiggerDrops/BiggerDrops/BiggerDrops.cs
+++ b/BiggerDrops/BiggerDrops/BiggerDrops.cs
@@ -10,10 +10,6 @@ namespace BiggerDrops {
     internal static string ModDirectory;
     public static Settings settings;
     public static int baysAlreadyAdded = 0;
-    public static bool argoUpgradesFixed = false;
-    //public static Transform UpgradeList1;
-    //public static Transform UpgradeList2;
-    //public static Transform UpgradeList3;
         public static void Init(string directory, string settingsJSON) {
       BiggerDrops.ModDirectory = directory;
       Logger.BaseDirectory = directory;

--- a/BiggerDrops/BiggerDrops/BiggerDrops.cs
+++ b/BiggerDrops/BiggerDrops/BiggerDrops.cs
@@ -3,13 +3,18 @@ using Newtonsoft.Json;
 using System;
 using System.IO;
 using System.Reflection;
+using UnityEngine;
 
 namespace BiggerDrops {
   public class BiggerDrops {
     internal static string ModDirectory;
     public static Settings settings;
-        public static int baysAlreadyAdded = 0;
-    public static void Init(string directory, string settingsJSON) {
+    public static int baysAlreadyAdded = 0;
+    public static bool argoUpgradesFixed = false;
+    //public static Transform UpgradeList1;
+    //public static Transform UpgradeList2;
+    //public static Transform UpgradeList3;
+        public static void Init(string directory, string settingsJSON) {
       BiggerDrops.ModDirectory = directory;
       Logger.BaseDirectory = directory;
       try {

--- a/BiggerDrops/BiggerDrops/BiggerDrops.cs
+++ b/BiggerDrops/BiggerDrops/BiggerDrops.cs
@@ -8,6 +8,7 @@ namespace BiggerDrops {
   public class BiggerDrops {
     internal static string ModDirectory;
     public static Settings settings;
+        public static int baysAlreadyAdded = 0;
     public static void Init(string directory, string settingsJSON) {
       BiggerDrops.ModDirectory = directory;
       Logger.BaseDirectory = directory;

--- a/BiggerDrops/BiggerDrops/BiggerDrops.csproj
+++ b/BiggerDrops/BiggerDrops/BiggerDrops.csproj
@@ -39,6 +39,10 @@
     <Reference Include="Assembly-CSharp">
       <HintPath>..\..\..\BattleTech_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
+    <Reference Include="Assembly-CSharp-firstpass, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>S:\Paradox\games\battletech\BattleTech_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\BattleTech_Data\Managed\Newtonsoft.Json.dll</HintPath>
@@ -79,7 +83,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy /Y "$(TargetPath)" "$(ProjectDir)..\..\..\Mods\BiggerDrop"</PostBuildEvent>
+    <PostBuildEvent>
+    </PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/BiggerDrops/BiggerDrops/HolderClasses.cs
+++ b/BiggerDrops/BiggerDrops/HolderClasses.cs
@@ -15,7 +15,11 @@ namespace BiggerDrops {
     public string additionalLanceName { get; set; }
     public bool allowUpgrades { get; set; }
     public bool showArgoUpgrades { get; set; }
-    public int additinalMechSlots {
+    public string argoUpgradeName { get; set; }
+    public string argoUpgradeCategory1Name { get; set; }
+    public string argoUpgradeCategory2Name { get; set; }
+    public string argoUpgradeCategory3Name { get; set; }
+        public int additinalMechSlots {
       get {
         if (allowUpgrades && companyStats != null)
         {
@@ -75,6 +79,10 @@ namespace BiggerDrops {
       FmaxTonnage = 500;
       allowUpgrades = false;
       showArgoUpgrades = true;
+      argoUpgradeName = "Command & Control";
+      argoUpgradeCategory1Name = "Drop Size";
+      argoUpgradeCategory2Name = "Mech Control";
+      argoUpgradeCategory3Name = "Drop Tonnage";
     }
     
     public void setCompanyStats(StatCollection stats) {

--- a/BiggerDrops/BiggerDrops/HolderClasses.cs
+++ b/BiggerDrops/BiggerDrops/HolderClasses.cs
@@ -1,18 +1,28 @@
 ﻿using Newtonsoft.Json;
 using System.Collections.Generic;
+using BattleTech;
 
 namespace BiggerDrops {
   public class Settings {
     public static readonly int MAX_ADDITINAL_MECH_SLOTS = 4;
     public static readonly int DEFAULT_MECH_SLOTS = 4;
     public static readonly string EMPLOYER_LANCE_GUID = "ecc8d4f2-74b4-465d-adf6-84445e5dfc230";
+    public static readonly string ADDITIONAL_MECH_STAT = "BiggerDrops_AdditionalMechSlots";
+    public static readonly string ADDITIONAL_PLAYER_MECH_STAT = "BiggerDrops_AdditionalPlayerMechSlots";
+    public static readonly string MAX_TONNAGE_STAT = "BiggerDrops_MaxTonnage";
     public bool debugLog { get; set; }
-    public int defaultMaxTonnage { get; set; }
     public int skirmishMax { get; set; }
     public string additionalLanceName { get; set; }
+    public bool allowUpgrades { get; set; }
+    public bool showArgoUpgrades { get; set; }
     public int additinalMechSlots {
       get {
-        if (FadditinalMechSlots < 0) { FadditinalMechSlots = 0; }
+        if (allowUpgrades && companyStats != null)
+        {
+            int val = companyStats.GetValue<int>(ADDITIONAL_MECH_STAT);
+            FadditinalMechSlots = val > MAX_ADDITINAL_MECH_SLOTS ? MAX_ADDITINAL_MECH_SLOTS : val;
+        }
+        if (FadditinalMechSlots < 0) { FadditinalMechSlots = 0; }       
         return FadditinalMechSlots;
       }
       set {
@@ -23,6 +33,11 @@ namespace BiggerDrops {
     }
     public int additinalPlayerMechSlots {
       get {
+        if (allowUpgrades && companyStats != null)
+        {
+            int val = companyStats.GetValue<int>(ADDITIONAL_PLAYER_MECH_STAT);
+            FadditinalPlayerMechSlots = val > MAX_ADDITINAL_MECH_SLOTS ? MAX_ADDITINAL_MECH_SLOTS : val;
+        }
         if (FadditinalPlayerMechSlots < 0) { FadditinalPlayerMechSlots = 0; }
         return FadditinalPlayerMechSlots;
       }
@@ -32,17 +47,44 @@ namespace BiggerDrops {
           if (FadditinalMechSlots < FadditinalPlayerMechSlots) { FadditinalPlayerMechSlots = FadditinalMechSlots; };
       }
     }
+    public int defaultMaxTonnage {
+            get {
+                if (allowUpgrades && companyStats != null)
+                {
+                    FmaxTonnage = companyStats.GetValue<int>(MAX_TONNAGE_STAT);
+                }
+                return FmaxTonnage;
+            }
+            set {
+                FmaxTonnage = value;
+            }
+        }
     [JsonIgnore]
     private int FadditinalMechSlots;
     [JsonIgnore]
     private int FadditinalPlayerMechSlots;
+    [JsonIgnore]
+    private int FmaxTonnage;
+    [JsonIgnore]
+    private StatCollection companyStats;
     public Settings() {
       debugLog = false;
       FadditinalMechSlots = -1;
       FadditinalPlayerMechSlots = -1;
       additionalLanceName = "AI LANCE";
-      defaultMaxTonnage = 500;
+      FmaxTonnage = 500;
+      allowUpgrades = false;
+      showArgoUpgrades = true;
     }
+    
+    public void setCompanyStats(StatCollection stats) {
+        companyStats = stats;
+            if (allowUpgrades) {
+                if (!companyStats.ContainsStatistic(ADDITIONAL_MECH_STAT)) { companyStats.AddStatistic(ADDITIONAL_MECH_STAT, FadditinalMechSlots); };
+                if (!companyStats.ContainsStatistic(ADDITIONAL_PLAYER_MECH_STAT)) { companyStats.AddStatistic(ADDITIONAL_PLAYER_MECH_STAT, FadditinalPlayerMechSlots); };
+                if (!companyStats.ContainsStatistic(MAX_TONNAGE_STAT)) { companyStats.AddStatistic(MAX_TONNAGE_STAT, FmaxTonnage); };
+            }
+     }
   }
 
   public class Fields {

--- a/BiggerDrops/BiggerDrops/HolderClasses.cs
+++ b/BiggerDrops/BiggerDrops/HolderClasses.cs
@@ -14,7 +14,7 @@ namespace BiggerDrops {
     public int skirmishMax { get; set; }
     public string additionalLanceName { get; set; }
     public bool allowUpgrades { get; set; }
-    public bool showArgoUpgrades { get; set; }
+    public bool showAdditionalArgoUpgrades { get; set; }
     public string argoUpgradeName { get; set; }
     public string argoUpgradeCategory1Name { get; set; }
     public string argoUpgradeCategory2Name { get; set; }
@@ -78,7 +78,7 @@ namespace BiggerDrops {
       additionalLanceName = "AI LANCE";
       FmaxTonnage = 500;
       allowUpgrades = false;
-      showArgoUpgrades = true;
+      showAdditionalArgoUpgrades = false;
       argoUpgradeName = "Command & Control";
       argoUpgradeCategory1Name = "Drop Size";
       argoUpgradeCategory2Name = "Mech Control";

--- a/BiggerDrops/BiggerDrops/Patch.cs
+++ b/BiggerDrops/BiggerDrops/Patch.cs
@@ -8,6 +8,8 @@ using System.Collections.Generic;
 using System.Linq;
 using TMPro;
 using UnityEngine;
+using UnityEngine.Events;
+using SVGImporter;
 
 namespace BiggerDrops {
 
@@ -387,6 +389,201 @@ namespace BiggerDrops {
             {
                 BiggerDrops.settings.setCompanyStats(__instance.CompanyStats);
             }
+        }
+    }
+
+    [HarmonyPatch(typeof(SGEngineeringScreen), "PopulateUpgradeDictionary")]
+    public static class SGEngineeringScreen_PopulateUpgradeDictionary
+    {
+        public static void Prefix(SGEngineeringScreen __instance)
+        {
+            try
+            {
+                if (__instance.transform.FindRecursive("BDUpgradePanel") == null) {
+                    GameObject primelayout = __instance.transform.FindRecursive("uixPrbPanl_SystemsAndSupportPanel").gameObject;
+                    GameObject newLayout = GameObject.Instantiate(primelayout);
+                    newLayout.transform.parent = primelayout.transform.parent;
+                    newLayout.name = "BDUpgradePanel";
+                    newLayout.transform.localPosition = new Vector3(-757, 195, 0);
+                    TextMeshProUGUI agroUpgradeText = newLayout.transform.FindRecursive("systemsAndSupport_header").gameObject.GetComponent<TextMeshProUGUI>();
+                    agroUpgradeText.text = BiggerDrops.settings.argoUpgradeName;
+                    TextMeshProUGUI upgrade1Text = newLayout.transform.FindRecursive("text_powerSystem").gameObject.GetComponent<TextMeshProUGUI>();
+                    upgrade1Text.text = BiggerDrops.settings.argoUpgradeCategory1Name;
+                    TextMeshProUGUI upgrade2Text = newLayout.transform.FindRecursive("text_structureSystem").gameObject.GetComponent<TextMeshProUGUI>();
+                    upgrade2Text.text = BiggerDrops.settings.argoUpgradeCategory2Name;
+                    TextMeshProUGUI upgrade3Text = newLayout.transform.FindRecursive("text_driveeSystem").gameObject.GetComponent<TextMeshProUGUI>();
+                    upgrade3Text.text = BiggerDrops.settings.argoUpgradeCategory3Name;
+                    GameObject habitat = newLayout.transform.FindRecursive("HabitatSystem").gameObject;
+                    habitat.name = "BDHabitat";
+                    habitat.SetActive(false);
+                    GameObject driverPipSlots = newLayout.transform.FindRecursive("drivePipSlots").gameObject;
+                    driverPipSlots.name = "BDMechDrops";
+                    GameObject structurePipSlots = newLayout.transform.FindRecursive("structurePipSlots").gameObject;
+                    structurePipSlots.name = "BDMechControl";
+                    GameObject powerPipSlots = newLayout.transform.FindRecursive("powerPipSlots").gameObject;
+                    powerPipSlots.name = "BDDropTonnage";
+
+                }
+            }
+            catch (Exception e)
+            {
+                Logger.LogError(e);
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(SGEngineeringScreen), "CleanUpAllUpgradePips")]
+    public static class SGEngineeringScreen_CleanUpAllUpgradePips
+    {
+        public static void Postfix(SGEngineeringScreen __instance)
+        {
+            try
+            {
+                if (__instance.transform.FindRecursive("BDUpgradePanel") != null)
+                {
+                    GameObject primelayout = __instance.transform.FindRecursive("BDUpgradePanel").gameObject;
+                    List<SGEngineeringShipUpgradePip> engineeringShipUpgradePipList = new List<SGEngineeringShipUpgradePip>();
+                    GameObject driverPipSlots = primelayout.transform.FindRecursive("BDMechDrops").gameObject;
+                    GameObject structurePipSlots = primelayout.transform.FindRecursive("BDMechControl").gameObject;
+                    GameObject powerPipSlots = primelayout.transform.FindRecursive("BDDropTonnage").gameObject;
+                    engineeringShipUpgradePipList.AddRange((IEnumerable<SGEngineeringShipUpgradePip>)driverPipSlots.GetComponentsInChildren<SGEngineeringShipUpgradePip>());
+                    engineeringShipUpgradePipList.AddRange((IEnumerable<SGEngineeringShipUpgradePip>)structurePipSlots.GetComponentsInChildren<SGEngineeringShipUpgradePip>());
+                    engineeringShipUpgradePipList.AddRange((IEnumerable<SGEngineeringShipUpgradePip>)powerPipSlots.GetComponentsInChildren<SGEngineeringShipUpgradePip>());
+                    List<ShipModuleUpgrade> available = (List<ShipModuleUpgrade>)AccessTools.Field(typeof(SGEngineeringScreen), "AvailableUpgrades").GetValue(__instance);
+                    List<ShipModuleUpgrade> purchased = (List<ShipModuleUpgrade>)AccessTools.Field(typeof(SGEngineeringScreen), "PurchasedUpgrades").GetValue(__instance);
+                    UIManager uiManager = (UIManager)AccessTools.Field(typeof(SGEngineeringScreen), "uiManager").GetValue(__instance);
+                    foreach (SGEngineeringShipUpgradePip engineeringShipUpgradePip in engineeringShipUpgradePipList)
+                    {
+                        string id = "uixPrfIndc_SIM_argoUpgradePipUnavailable-element";
+
+                        if (available.Contains(engineeringShipUpgradePip.UpgradeModule))
+                            id = "uixPrfIndc_SIM_argoUpgradePipAvailable-element";
+                        else if (purchased.Contains(engineeringShipUpgradePip.UpgradeModule))
+                            id = "uixPrfIndc_SIM_argoUpgradePip-element";
+                        uiManager.dataManager.PoolGameObject(id, engineeringShipUpgradePip.gameObject);
+                    }
+
+                }
+            }
+            catch (Exception e)
+            {
+                Logger.LogError(e);
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(SGEngineeringScreen), "ClearUpgradePips")]
+    public static class SGEngineeringScreen_ClearUpgradePips
+    {
+        public static void Postfix(SGEngineeringScreen __instance)
+        {
+            try
+            {
+                if (__instance.transform.FindRecursive("BDUpgradePanel") != null)
+                {
+                    GameObject primelayout = __instance.transform.FindRecursive("BDUpgradePanel").gameObject;
+                    List<GameObject> engineeringShipUpgradePipList = new List<GameObject>();
+                    GameObject driverPipSlots = primelayout.transform.FindRecursive("BDMechDrops").gameObject;
+                    foreach (Transform transform in driverPipSlots.transform)
+                    {
+                        if ((UnityEngine.Object)transform.gameObject.GetComponent<SGEngineeringShipUpgradePip>() != (UnityEngine.Object)null)
+                            engineeringShipUpgradePipList.Add(transform.gameObject);
+                    }
+                    GameObject structurePipSlots = primelayout.transform.FindRecursive("BDMechControl").gameObject;
+                    foreach (Transform transform in structurePipSlots.transform)
+                    {
+                        if ((UnityEngine.Object)transform.gameObject.GetComponent<SGEngineeringShipUpgradePip>() != (UnityEngine.Object)null)
+                            engineeringShipUpgradePipList.Add(transform.gameObject);
+                    }
+                    GameObject powerPipSlots = primelayout.transform.FindRecursive("BDDropTonnage").gameObject;
+                    foreach (Transform transform in powerPipSlots.transform)
+                    {
+                        if ((UnityEngine.Object)transform.gameObject.GetComponent<SGEngineeringShipUpgradePip>() != (UnityEngine.Object)null)
+                            engineeringShipUpgradePipList.Add(transform.gameObject);
+                    }
+                    List<ShipModuleUpgrade> available = (List<ShipModuleUpgrade>)AccessTools.Field(typeof(SGEngineeringScreen), "AvailableUpgrades").GetValue(__instance);
+                    List<ShipModuleUpgrade> purchased = (List<ShipModuleUpgrade>)AccessTools.Field(typeof(SGEngineeringScreen), "PurchasedUpgrades").GetValue(__instance);
+                    SimGameState simGame = (SimGameState)AccessTools.Property(typeof(SGEngineeringScreen), "simState").GetValue(__instance);
+                    engineeringShipUpgradePipList.ForEach((Action<GameObject>)(item =>
+                    {
+                        string id = "uixPrfIndc_SIM_argoUpgradePipUnavailable-element";
+                        ShipModuleUpgrade upgradeModule = item.GetComponent<SGEngineeringShipUpgradePip>().UpgradeModule;
+                        if (available.Contains(upgradeModule))
+                            id = "uixPrfIndc_SIM_argoUpgradePipAvailable-element";
+                        else if (purchased.Contains(upgradeModule))
+                            id = "uixPrfIndc_SIM_argoUpgradePip-element";
+                        simGame.DataManager.PoolGameObject(id, item);
+                    }));
+                }
+            }
+            catch (Exception e)
+            {
+                Logger.LogError(e);
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(SGEngineeringScreen), "AddUpgradePip")]
+    public static class SGEngineeringScreen_AddUpgradePip
+    {
+        public static void UpgradeSelected(this SGEngineeringScreen screen, ShipModuleUpgrade upgrade)
+        {
+            AccessTools.Method(typeof(SGEngineeringScreen), "OnUpgradeSelected").Invoke(screen, new object[] { upgrade });
+        }
+        public static bool Prefix(SGEngineeringScreen __instance, ShipModuleUpgrade upgrade)
+        {
+            try
+            {   
+                if (upgrade.Location != DropshipLocation.UNKNOWN)
+                {
+                    return true;
+                }
+
+                if (__instance.transform.FindRecursive("BDUpgradePanel") != null)
+                {
+                    GameObject primelayout = __instance.transform.FindRecursive("BDUpgradePanel").gameObject;
+                    Transform driverPipSlots = primelayout.transform.FindRecursive("BDMechDrops");
+                    Transform structurePipSlots = primelayout.transform.FindRecursive("BDMechControl");
+                    Transform powerPipSlots = primelayout.transform.FindRecursive("BDDropTonnage");
+                    List<ShipModuleUpgrade> available = (List<ShipModuleUpgrade>)AccessTools.Field(typeof(SGEngineeringScreen), "AvailableUpgrades").GetValue(__instance);
+                    List<ShipModuleUpgrade> purchased = (List<ShipModuleUpgrade>)AccessTools.Field(typeof(SGEngineeringScreen), "PurchasedUpgrades").GetValue(__instance);
+                    SimGameState simGame = (SimGameState)AccessTools.Property(typeof(SGEngineeringScreen), "simState").GetValue(__instance);
+                    UIManager uiManager = (UIManager)AccessTools.Field(typeof(SGEngineeringScreen), "uiManager").GetValue(__instance);
+                    Transform parent;
+                    switch (upgrade.Category)
+                    {
+                        case ShipUpgradeCategory.POWER_SYSTEM:
+                            parent = powerPipSlots;
+                            break;
+                        case ShipUpgradeCategory.STRUCTURE:
+                            parent = structurePipSlots;
+                            break;
+                        case ShipUpgradeCategory.DRIVE_SYSTEM:
+                            parent = driverPipSlots;
+                            break;
+                        default:
+                            Debug.LogWarning((object)string.Format("Invalid location ({0}) for ship module {1}", (object)upgrade.Location, (object)upgrade.Description.Id));
+                            return false;
+                    }
+                    string id = "uixPrfIndc_SIM_argoUpgradePipUnavailable-element";
+                    if (available.Contains(upgrade))
+                        id = "uixPrfIndc_SIM_argoUpgradePipAvailable-element";
+                    else if (purchased.Contains(upgrade))
+                        id = "uixPrfIndc_SIM_argoUpgradePip-element";
+                    SGEngineeringShipUpgradePip component = uiManager.dataManager.PooledInstantiate(id, BattleTechResourceType.UIModulePrefabs, new Vector3?(), new Quaternion?(), parent).GetComponent<SGEngineeringShipUpgradePip>();
+                    component.transform.localScale = Vector3.one;
+                    component.SetUpgadeModule(upgrade);
+                    simGame.RequestItem<SVGAsset>(upgrade.Description.Icon, new Action<SVGAsset>(component.SetIcon), BattleTechResourceType.SVGAsset);
+                    component.OnModuleSelected.RemoveAllListeners();
+                    component.OnModuleSelected.AddListener(new UnityAction<ShipModuleUpgrade>(__instance.UpgradeSelected));
+                }
+      
+            }
+            catch (Exception e)
+            {
+                Logger.LogError(e);
+            }
+            return false;
         }
     }
 

--- a/BiggerDrops/BiggerDrops/Patch.cs
+++ b/BiggerDrops/BiggerDrops/Patch.cs
@@ -397,8 +397,13 @@ namespace BiggerDrops {
     {
         public static void Prefix(SGEngineeringScreen __instance)
         {
+            if (!BiggerDrops.settings.showAdditionalArgoUpgrades)
+            {
+                return;
+            }
             try
             {
+                //This needs to be done by as a prefix to avoid strange bugs with upgrades showing the wrong state
                 if (__instance.transform.FindRecursive("BDUpgradePanel") == null) {
                     GameObject primelayout = __instance.transform.FindRecursive("uixPrbPanl_SystemsAndSupportPanel").gameObject;
                     GameObject newLayout = GameObject.Instantiate(primelayout);
@@ -532,8 +537,13 @@ namespace BiggerDrops {
         }
         public static bool Prefix(SGEngineeringScreen __instance, ShipModuleUpgrade upgrade)
         {
+            if (!BiggerDrops.settings.showAdditionalArgoUpgrades)
+            {
+                return true;
+            }
             try
             {   
+                //Todo: clean this up once ShipUpgradeCategory is made into a dynamic enum
                 if (upgrade.Location != DropshipLocation.UNKNOWN)
                 {
                     return true;

--- a/BiggerDrops/BiggerDrops/PortraitsCount.cs
+++ b/BiggerDrops/BiggerDrops/PortraitsCount.cs
@@ -170,6 +170,7 @@ namespace BiggerDrops {
     public static void Postfix(CombatHUDMechwarriorTray __instance, CombatGameState Combat, CombatHUD HUD) {
       Logger.M.TWL(0, "CombatHUDMechwarriorTray.Init postfix");
       try {
+        if (__instance.PortraitHolders.Length <= 4) { return; }
         for (int index = 0; index < __instance.PortraitHolders.Length; ++index) {
           Vector3[] corners = new Vector3[4];
           __instance.PortraitHolders[index].GetComponent<RectTransform>().GetWorldCorners(corners);


### PR DESCRIPTION
allows bigger drops mech and tonnage limits to be upgraded from the argo upgrades (should also open up the possibility for events). also optionally creates some additional upgrade categories on the argo upgrade screen.